### PR TITLE
Retry on "ActiveRecord::Deadlocked" errors (in addition to ActiveRecord::LockWaitTimeout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 deadlock_retry changes
 
+== v2.2.0
+
+* Retry on ActiveRecord::Deadlocked, in addition to ActiveRecord::LockWaitTimeout
+
 == v2.1.0
 
 * update for rails 5 keyword args

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 deadlock_retry changes
 
-== v2.2.0
+== v2.2.1
 
 * Retry on ActiveRecord::Deadlocked, in addition to ActiveRecord::LockWaitTimeout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 deadlock_retry changes
 
-== v2.2.1
+== v2.2.2
 
 * Retry on ActiveRecord::Deadlocked, in addition to ActiveRecord::LockWaitTimeout
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deadlock_retry (2.2.1)
+    deadlock_retry (2.2.2)
 
 GEM
   remote: http://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,30 @@
 PATH
   remote: .
   specs:
-    deadlock_retry (2.1.0)
+    deadlock_retry (2.2.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (7.2.2.1)
-      activesupport (= 7.2.2.1)
-    activerecord (7.2.2.1)
-      activemodel (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
+    activemodel (7.1.5.1)
+      activesupport (= 7.1.5.1)
+    activerecord (7.1.5.1)
+      activemodel (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       timeout (>= 0.4.0)
-    activesupport (7.2.2.1)
+    activesupport (7.1.5.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
       minitest (>= 5.1)
+      mutex_m
       securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
+      tzinfo (~> 2.0)
     base64 (0.2.0)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
@@ -39,6 +40,7 @@ GEM
       minitest (~> 5)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
+    mutex_m (0.3.0)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
     timeout (0.4.3)
@@ -49,7 +51,7 @@ PLATFORMS
   aarch64-linux
 
 DEPENDENCIES
-  activerecord (~> 7.1)
+  activerecord (~> 7.1.5.1)
   byebug
   deadlock_retry!
   minitest-color

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deadlock_retry (2.2.0)
+    deadlock_retry (2.2.1)
 
 GEM
   remote: http://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,58 @@
 PATH
   remote: .
   specs:
-    deadlock_retry (1.2.0)
+    deadlock_retry (2.1.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (6.1.7.2)
-      activesupport (= 6.1.7.2)
-    activerecord (6.1.7.2)
-      activemodel (= 6.1.7.2)
-      activesupport (= 6.1.7.2)
-    activesupport (6.1.7.2)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activemodel (7.2.2.1)
+      activesupport (= 7.2.2.1)
+    activerecord (7.2.2.1)
+      activemodel (= 7.2.2.1)
+      activesupport (= 7.2.2.1)
+      timeout (>= 0.4.0)
+    activesupport (7.2.2.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    concurrent-ruby (1.2.0)
-    i18n (1.12.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.2.0)
+    benchmark (0.4.0)
+    bigdecimal (3.1.9)
+    byebug (11.1.3)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
+    drb (2.2.1)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    minitest (5.17.0)
+    logger (1.6.6)
+    minitest (5.25.5)
+    minitest-color (0.0.2)
+      minitest (~> 5)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
     ruby2_keywords (0.0.5)
+    securerandom (0.4.1)
+    timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.6)
 
 PLATFORMS
   aarch64-linux
 
 DEPENDENCIES
-  activerecord (~> 6.0)
+  activerecord (~> 7.1)
+  byebug
   deadlock_retry!
+  minitest-color
   mocha
 
 BUNDLED WITH

--- a/README
+++ b/README
@@ -15,3 +15,23 @@ Add it to your Rails application by installing the gem:
 and including a reference to it in your application's Gemfile:
 
   gem 'deadlock_retry'
+
+
+## Installation
+
+```
+cd ~/dev
+git clone git@github.com:cdd/deadlock_retry.git
+cd deadlock_retry
+
+# build the docker container
+make
+
+# manually update the Gemfile.lock
+make shell
+bundle install
+exit
+
+# run the the test suite
+make test
+```

--- a/README
+++ b/README
@@ -35,3 +35,9 @@ exit
 # run the the test suite
 make test
 ```
+
+## Development
+
+```
+make guard
+```

--- a/README
+++ b/README
@@ -41,3 +41,17 @@ make test
 ```
 make guard
 ```
+
+## Bumping the version
+
+1. Bump the version number in `lib/deadlock_retry/version.rb`
+
+2. Add an entry to `CHANGELOG.md`
+
+3. Run the following so Gemfile.lock is updated:
+
+```
+make shell
+bundle install
+exit
+```

--- a/deadlock_retry.gemspec
+++ b/deadlock_retry.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://github.com/mperham/deadlock_retry}
   s.require_paths = ["lib"]
   s.add_development_dependency 'mocha'
-  s.add_development_dependency 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>6.0'
+  s.add_development_dependency 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~> 7.1.5.1'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'minitest-color'
 end

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -14,18 +14,18 @@ module DeadlockRetry
       super(requires_new: requires_new, isolation: isolation, joinable: joinable, &block)
     rescue ActiveRecord::LockWaitTimeout, ActiveRecord::Deadlocked => e
       if in_nested_transaction?
-        logger.info { "DeadlockRetry: [NESTED_TRANSACTION] Deadlock detected in a nested transaction, not retrying. [#{e.class}]" }
+        logger.info { "CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [#{e.class}]" }
         raise
       end
 
       if retry_count >= MAXIMUM_RETRIES_ON_DEADLOCK
-        logger.info { "DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: #{MAXIMUM_RETRIES_ON_DEADLOCK}), not retrying. [#{e.class}]" }
+        logger.info { "CDD_DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: #{MAXIMUM_RETRIES_ON_DEADLOCK}), not retrying. [#{e.class}]" }
         raise
       end
 
       retry_count += 1
       pause_seconds = exponential_pause_seconds(retry_count)
-      logger.info { "DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry #{retry_count}, retrying transaction in #{pause_seconds} seconds. [#{e.class}]" }
+      logger.info { "CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry #{retry_count}, retrying transaction in #{pause_seconds} seconds. [#{e.class}]" }
       log_innodb_status if DeadlockRetry.innodb_status_cmd
       sleep_pause(pause_seconds)
       retry

--- a/lib/deadlock_retry/version.rb
+++ b/lib/deadlock_retry/version.rb
@@ -1,3 +1,3 @@
 module DeadlockRetry
-  VERSION = '2.2.1'
+  VERSION = '2.2.2'
 end

--- a/lib/deadlock_retry/version.rb
+++ b/lib/deadlock_retry/version.rb
@@ -1,3 +1,3 @@
 module DeadlockRetry
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end

--- a/lib/deadlock_retry/version.rb
+++ b/lib/deadlock_retry/version.rb
@@ -1,3 +1,3 @@
 module DeadlockRetry
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end

--- a/test/deadlock_retry_test.rb
+++ b/test/deadlock_retry_test.rb
@@ -85,13 +85,6 @@ class DeadlockRetryTest < Minitest::Test
     DeadlockRetry.class_variable_set(:@@deadlock_logger_severity, nil)
   end
 
-  def print_logs(logs)
-    puts "\n"
-    puts "*" * 100
-    puts logs
-    puts "@" * 100
-  end
-
   def test_no_errors
     assert_equal :success, MockModel.transaction { :success }
   end

--- a/test/deadlock_retry_test.rb
+++ b/test/deadlock_retry_test.rb
@@ -171,6 +171,18 @@ class DeadlockRetryTest < Minitest::Test
     log_io.rewind
     logs = log_io.read
 
+    # here is an example output of the logs:
+    # I, [2025-03-20T20:54:47.157839 #8]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::Deadlocked]
+    # W, [2025-03-20T20:54:47.157844 #8]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:54:47.157847 #8]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:54:47.157851 #8]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::Deadlocked]
+    # W, [2025-03-20T20:54:47.157853 #8]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:54:47.157855 #8]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:54:47.157858 #8]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::Deadlocked]
+    # W, [2025-03-20T20:54:47.157860 #8]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:54:47.157862 #8]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:54:47.157865 #8]  INFO -- : CDD_DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::Deadlocked]
+
     assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::Deadlocked]")
     assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::Deadlocked]")
     assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::Deadlocked]")
@@ -187,9 +199,20 @@ class DeadlockRetryTest < Minitest::Test
       MockModel.transaction { raise ActiveRecord::LockWaitTimeout, TIMEOUT_ERROR }
     end
 
-    test_no_errors_with_lock_timeout
     log_io.rewind
     logs = log_io.read
+
+    # here is an example output of the logs:
+    # I, [2025-03-20T20:54:15.136562 #8]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::LockWaitTimeout]
+    # W, [2025-03-20T20:54:15.136566 #8]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:54:15.136568 #8]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:54:15.136572 #8]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::LockWaitTimeout]
+    # W, [2025-03-20T20:54:15.136575 #8]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:54:15.136577 #8]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:54:15.136580 #8]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::LockWaitTimeout]
+    # W, [2025-03-20T20:54:15.136583 #8]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:54:15.136585 #8]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:54:15.136588 #8]  INFO -- : CDD_DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::LockWaitTimeout]
 
     assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::LockWaitTimeout]")
     assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::LockWaitTimeout]")
@@ -266,6 +289,26 @@ class DeadlockRetryTest < Minitest::Test
     log_io.rewind
     logs = log_io.read
 
+    # here is an example output of the logs:
+    # I, [2025-03-20T20:51:44.959981 #8]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::Deadlocked]
+    # I, [2025-03-20T20:51:44.959996 #8]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::Deadlocked]
+    # I, [2025-03-20T20:51:44.960000 #8]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::Deadlocked]
+    # W, [2025-03-20T20:51:44.960003 #8]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:51:44.960005 #8]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:51:44.960009 #8]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::Deadlocked]
+    # I, [2025-03-20T20:51:44.960022 #8]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::Deadlocked]
+    # I, [2025-03-20T20:51:44.960026 #8]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::Deadlocked]
+    # W, [2025-03-20T20:51:44.960041 #8]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:51:44.960043 #8]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:51:44.960047 #8]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::Deadlocked]
+    # I, [2025-03-20T20:51:44.960059 #8]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::Deadlocked]
+    # I, [2025-03-20T20:51:44.960063 #8]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::Deadlocked]
+    # W, [2025-03-20T20:51:44.960085 #8]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:51:44.960088 #8]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:51:44.960108 #8]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::Deadlocked]
+    # I, [2025-03-20T20:51:44.960124 #8]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::Deadlocked]
+    # I, [2025-03-20T20:51:44.960128 #8]  INFO -- : CDD_DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::Deadlocked]
+
     assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::Deadlocked]")
     assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::Deadlocked]")
     assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::Deadlocked]")
@@ -274,7 +317,7 @@ class DeadlockRetryTest < Minitest::Test
     assert_equal 8, logs.scan("CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::Deadlocked]").size
   end
 
-  def test_logs_in_nested_transaction_with_deadlock
+  def test_logs_in_nested_transaction_with_lock_timeout
     log_io = StringIO.new
     log = Logger.new(log_io)
     MockModel.logger = log
@@ -291,6 +334,26 @@ class DeadlockRetryTest < Minitest::Test
 
     log_io.rewind
     logs = log_io.read
+
+    # here is an example output of the logs:
+    # I, [2025-03-20T20:53:01.650127 #7]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::LockWaitTimeout]
+    # I, [2025-03-20T20:53:01.650143 #7]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::LockWaitTimeout]
+    # I, [2025-03-20T20:53:01.650147 #7]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::LockWaitTimeout]
+    # W, [2025-03-20T20:53:01.650150 #7]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:53:01.650152 #7]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:53:01.650156 #7]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::LockWaitTimeout]
+    # I, [2025-03-20T20:53:01.650169 #7]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::LockWaitTimeout]
+    # I, [2025-03-20T20:53:01.650172 #7]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::LockWaitTimeout]
+    # W, [2025-03-20T20:53:01.650175 #7]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:53:01.650177 #7]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:53:01.650180 #7]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::LockWaitTimeout]
+    # I, [2025-03-20T20:53:01.650192 #7]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::LockWaitTimeout]
+    # I, [2025-03-20T20:53:01.650196 #7]  INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::LockWaitTimeout]
+    # W, [2025-03-20T20:53:01.650199 #7]  WARN -- : INNODB Status follows:
+    # W, [2025-03-20T20:53:01.650201 #7]  WARN -- : FAKE INNODB STATUS HERE
+    # I, [2025-03-20T20:53:01.650205 #7]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::LockWaitTimeout]
+    # I, [2025-03-20T20:53:01.650216 #7]  INFO -- : CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::LockWaitTimeout]
+    # I, [2025-03-20T20:53:01.650220 #7]  INFO -- : CDD_DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::LockWaitTimeout]
 
     assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::LockWaitTimeout]")
     assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::LockWaitTimeout]")

--- a/test/deadlock_retry_test.rb
+++ b/test/deadlock_retry_test.rb
@@ -142,9 +142,9 @@ class DeadlockRetryTest < Minitest::Test
     log_io.rewind
     logs = log_io.read
 
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::Deadlocked]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::Deadlocked]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::Deadlocked]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::Deadlocked]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::Deadlocked]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::Deadlocked]")
   end
 
   def test_logs_at_level_info_by_default_with_lock_timeout
@@ -154,9 +154,9 @@ class DeadlockRetryTest < Minitest::Test
     test_no_errors_with_lock_timeout
     log_io.rewind
     logs = log_io.read
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::LockWaitTimeout]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::LockWaitTimeout]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::LockWaitTimeout]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::LockWaitTimeout]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::LockWaitTimeout]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::LockWaitTimeout]")
   end
 
   def test_logs_if_limit_exceeded_with_deadlock
@@ -171,11 +171,11 @@ class DeadlockRetryTest < Minitest::Test
     log_io.rewind
     logs = log_io.read
 
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::Deadlocked]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::Deadlocked]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::Deadlocked]")
-    refute_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 4")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::Deadlocked]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::Deadlocked]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::Deadlocked]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::Deadlocked]")
+    refute_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 4")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::Deadlocked]")
   end
 
   def test_logs_if_limit_exceeded_with_lock_timeout
@@ -191,11 +191,11 @@ class DeadlockRetryTest < Minitest::Test
     log_io.rewind
     logs = log_io.read
 
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::LockWaitTimeout]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::LockWaitTimeout]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::LockWaitTimeout]")
-    refute_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 4")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::LockWaitTimeout]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::LockWaitTimeout]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::LockWaitTimeout]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::LockWaitTimeout]")
+    refute_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 4")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::LockWaitTimeout]")
   end
 
   def test_error_if_unrecognized_error
@@ -266,12 +266,12 @@ class DeadlockRetryTest < Minitest::Test
     log_io.rewind
     logs = log_io.read
 
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::Deadlocked]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::Deadlocked]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::Deadlocked]")
-    refute_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 4")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::Deadlocked]")
-    assert_equal 8, logs.scan("DeadlockRetry: [NESTED_TRANSACTION] Deadlock detected in a nested transaction, not retrying. [ActiveRecord::Deadlocked]").size
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::Deadlocked]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::Deadlocked]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::Deadlocked]")
+    refute_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 4")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::Deadlocked]")
+    assert_equal 8, logs.scan("CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::Deadlocked]").size
   end
 
   def test_logs_in_nested_transaction_with_deadlock
@@ -292,11 +292,11 @@ class DeadlockRetryTest < Minitest::Test
     log_io.rewind
     logs = log_io.read
 
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::LockWaitTimeout]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::LockWaitTimeout]")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::LockWaitTimeout]")
-    refute_includes(logs, "INFO -- : DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 4")
-    assert_includes(logs, "INFO -- : DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::LockWaitTimeout]")
-    assert_equal 8, logs.scan("DeadlockRetry: [NESTED_TRANSACTION] Deadlock detected in a nested transaction, not retrying. [ActiveRecord::LockWaitTimeout]").size
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 1, retrying transaction in 0 seconds. [ActiveRecord::LockWaitTimeout]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 2, retrying transaction in 1 seconds. [ActiveRecord::LockWaitTimeout]")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 3, retrying transaction in 2 seconds. [ActiveRecord::LockWaitTimeout]")
+    refute_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_RETRYING_TRANSACTION Deadlock detected on retry 4")
+    assert_includes(logs, "INFO -- : CDD_DEADLOCK_RETRY_MAXIMUM_RETRIES_EXCEEDED Deadlock detected and maximum retries exceeded (maximum: 3), not retrying. [ActiveRecord::LockWaitTimeout]")
+    assert_equal 8, logs.scan("CDD_DEADLOCK_RETRY_NESTED_TRANSACTION Deadlock detected in a nested transaction, not retrying. [ActiveRecord::LockWaitTimeout]").size
   end
 end


### PR DESCRIPTION
Context: Before this PR, the gem was rescuing from `ActiveRecord::LockWaitTimeout` exceptions (which is good), but `ActiveRecord::Deadlocked` exceptions were not getting caught (which is the issue).  That means when our rails app is throwing a `Mysql2::Error: Deadlock found when trying to get lock; try restarting transaction` error, our `deadlock_retry` gem was not retrying the transaction.

Fix: After this PR, we rescue from both exceptions todo the retry logic.

Notes:

1) The logger was improved with a few things:
* which activerecord exception class was raised
* when we've reached the max number of retries
* when we're in a nested transaction, therefore the outer transaction will do the retry

2) The exceptions we are rescuing from are the same as the ones which Rails' built-in deadlock retry use (ala Rails 7.1): https://github.com/rails/rails/blob/e9d7ca5e0b834ff2ce3d43965deac670ff8ac790/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1079.  This is good from a "we are retrying on the right things" and from a perspective that "hopefully we can cleanly migrate off this gem and onto Rails default behavior easily" in the near future.

3) Added some README directions for install/setup.

4) This PR should fix the dependabot security alerts:
* https://github.com/cdd/deadlock_retry/security/dependabot/2
* https://github.com/cdd/deadlock_retry/security/dependabot/1
